### PR TITLE
update how to install docker-engine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,13 @@
 FROM centos:7
 
 # setup docker.repo
-RUN echo -e "[dockerrepo]\nname=Docker Repository\nbaseurl=https://yum.dockerproject.org/repo/main/centos/\$releasever/\nenabled=1\ngpgcheck=1\ngpgkey=https://yum.dockerproject.org/gpg" >> /etc/yum.repos.d/docker.repo
+RUN yum -y install yum-utils \
+  && yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
 # setup mackerel-agent docker-engine
 RUN curl -fsSL https://mackerel.io/file/script/amznlinux/setup-yum.sh | sed -r 's/sudo( -k)?//' | sh \
   && sed -i.bak 's/$releasever/latest/' /etc/yum.repos.d/mackerel.repo \
   && yum -y install mackerel-agent mackerel-agent-plugins mackerel-check-plugins \
-  && yum -y install docker-engine \
+  && yum -y install docker-ce docker-ce-cli containerd.io \
   && yum clean all
 
 ADD startup.sh /startup.sh


### PR DESCRIPTION
Currently `docker build` will fail with **404 - Not Found**; details:

```
To install mackerel-agent type: yum install mackerel-agent
Loaded plugins: fastestmirror, ovl
Determining fastest mirrors
* base: d36uatko69830t.cloudfront.net
* extras: d36uatko69830t.cloudfront.net
* updates: d36uatko69830t.cloudfront.net
https://yum.dockerproject.org/repo/main/centos/7/repodata/repomd.xml: [Errno 14] HTTPS Error 404 - Not Found
Trying other mirror.
To address this issue please refer to the below wiki article
https://wiki.centos.org/yum-errors
```

I updated the installation of docker-engine with the steps of official installation guide.
https://docs.docker.com/engine/install/centos/

And I checked to be measured for metrics of mackerel-plugin-docker.

```sh
docker run -h `hostname` \
  -v /var/run/docker.sock:/var/run/docker.sock \
  -e 'apikey=xxx' \
  -e 'auto_retirement=1' \
  -e 'enable_docker_plugin=1' \
  -d \
  mackerel/mackerel-agent
```