### PR TITLE
Update package repository (and base image)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update \
 RUN curl -fsSL  https://mackerel.io/file/script/setup-apt-v2.sh | sh
 
 # setup docker repo
+# ref: https://docs.docker.com/engine/install/debian/
 RUN curl -fsSL https://download.docker.com/linux/debian/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg \
   && echo \
     "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,26 @@
-FROM centos:7
+FROM debian:buster-slim
 
-# setup docker.repo
-RUN yum -y install yum-utils \
-  && yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
-# setup mackerel-agent docker-engine
-RUN curl -fsSL https://mackerel.io/file/script/amznlinux/setup-yum.sh | sed -r 's/sudo( -k)?//' | sh \
-  && sed -i.bak 's/$releasever/latest/' /etc/yum.repos.d/mackerel.repo \
-  && yum -y install mackerel-agent mackerel-agent-plugins mackerel-check-plugins \
-  && yum -y install docker-ce docker-ce-cli containerd.io \
-  && yum clean all
+# setup tools
+RUN apt-get update \
+  && apt-get install -y sudo ca-certificates curl gnupg2 lsb-release \
+  && rm -rf /var/lib/apt/lists/*
 
-ADD startup.sh /startup.sh
+# setup mackerel-agent repo
+RUN curl -fsSL  https://mackerel.io/file/script/setup-apt-v2.sh | sh
+
+# setup docker repo
+RUN curl -fsSL https://download.docker.com/linux/debian/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg \
+  && echo \
+    "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian \
+    $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+# setup mackerel-agent and docker
+RUN apt-get update \
+  && apt-get install -y mackerel-agent mackerel-agent-plugins mackerel-check-plugins \
+  && apt-get install -y docker-ce docker-ce-cli containerd.io \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY startup.sh /startup.sh
 RUN chmod 755 /startup.sh
 
 # boot mackerel-agent

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:buster-slim
 
 # setup tools
 RUN apt-get update \
-  && apt-get install -y sudo ca-certificates curl gnupg2 lsb-release \
+  && apt-get install -y sudo ca-certificates curl gnupg2 lsb-release net-tools \
   && rm -rf /var/lib/apt/lists/*
 
 # setup mackerel-agent repo


### PR DESCRIPTION
This PR updates the package repository to [the new one](https://mackerel.io/blog/entry/announcement/20170616) (not that new though 😅).
The benefits of this change are 1. multi-arch (both amd64 and arm64) support and 2. smaller image size.

Along with that, I changed the base image from `centos:7` to `debian:buster-slim`, as it is (I think) more popular and better (lightweight, etc.) as a base image...
Some plugins that depend on external commands may be affected by this change, but as far as I checked, they will not.
