### PR TITLE
Add GitHub Actions workflow to build and push docker images (Part 2)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,11 +1,8 @@
-# This workflow is under construction.
-# See https://github.com/mackerelio/docker-mackerel-agent/pull/5
 name: Build
 on:
-  # push:
-  #   tags:
-  #     - '[0-9]+.[0-9]+.[0-9]+'
-  workflow_dispatch:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -16,15 +13,14 @@ jobs:
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      # - name: Login to Docker Hub
-      #   uses: docker/login-action@v1
-      #   with:
-      #     username: ${{ secrets.DOCKERHUB_USERNAME }}
-      #     password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Get tag
         id: get_tag
-        # run: echo "::set-output name=tag::${GITHUB_REF##*/}"
-        run: echo "::set-output name=tag::x.y.z"
+        run: echo "::set-output name=tag::${GITHUB_REF##*/}"
       - name: Build and push
         uses: docker/build-push-action@v2
         with:
@@ -32,7 +28,7 @@ jobs:
           platforms: |
             linux/amd64
             linux/arm64
-          # push: true
+          push: true
           tags: |
             mackerel/mackerel-agent:latest
             mackerel/mackerel-agent:${{ steps.get_tag.outputs.tag }}


### PR DESCRIPTION
Prev: #5

Enable pushing to [Docker Hub](https://hub.docker.com/r/mackerel/mackerel-agent).
