### PR TITLE
remove docker-ce on container.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,17 +8,9 @@ RUN apt-get update \
 # setup mackerel-agent repo
 RUN curl -fsSL  https://mackerel.io/file/script/setup-apt-v2.sh | sh
 
-# setup docker repo
-# ref: https://docs.docker.com/engine/install/debian/
-RUN curl -fsSL https://download.docker.com/linux/debian/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg \
-  && echo \
-    "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian \
-    $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-
-# setup mackerel-agent and docker
+# setup mackerel-agent
 RUN apt-get update \
   && apt-get install -y mackerel-agent mackerel-agent-plugins mackerel-check-plugins \
-  && apt-get install -y docker-ce docker-ce-cli containerd.io \
   && rm -rf /var/lib/apt/lists/*
 
 COPY startup.sh /startup.sh

--- a/startup.sh
+++ b/startup.sh
@@ -15,7 +15,7 @@ fi
 if [ "$enable_docker_plugin" != "" ] && [ "$enable_docker_plugin" != "0" ] && ! grep '^\[plugin\.metrics\.docker\]' $conf; then
     cat >> $conf << "EOF"
 [plugin.metrics.docker]
-command = "/usr/bin/mackerel-plugin-docker -method API -name-format name"
+command = "/usr/bin/mackerel-plugin-docker -name-format name"
 EOF
 fi
 


### PR DESCRIPTION
Plug-ins that depended on docker-ce are no longer dependent on it due to [code updates](https://github.com/mackerelio/mackerel-agent-plugins/releases/tag/v0.72.0 ).

Therefore, change to not install docker-ce.

It also contributes to container size reduction.

| Image Name | Size (according to `docker images`) |
|--|--|
| mackerel/mackerel-agent | 711MB |
| this modified | 201MB |